### PR TITLE
Updating websocket-extensions to version 0.1.5

### DIFF
--- a/rails_app/Gemfile
+++ b/rails_app/Gemfile
@@ -11,15 +11,15 @@ gem 'jquery-rails'
 # Use postgresql as the database for Active Record
 gem 'pg', '0.21.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.4'
+gem 'rails', '5.2.4.3'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', '~> 0.4.0', group: :doc
+gem 'sdoc', group: :doc
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 

--- a/rails_app/Gemfile.lock
+++ b/rails_app/Gemfile.lock
@@ -60,10 +60,10 @@ GEM
     diff-lcs (1.3)
     erubi (1.9.0)
     execjs (2.7.0)
-    ffi (1.12.2)
+    ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -71,7 +71,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.6)
     loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -119,7 +118,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (4.3.0)
+    rdoc (6.2.1)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -148,9 +147,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sdoc (0.4.2)
-      json (~> 1.7, >= 1.7.7)
-      rdoc (~> 4.0)
+    sdoc (1.1.0)
+      rdoc (>= 5.0)
     spring (2.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -176,7 +174,7 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
 
 PLATFORMS
   ruby
@@ -187,13 +185,13 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   pg (= 0.21.0)
-  rails (~> 5.2.4)
+  rails (= 5.2.4.3)
   rspec-rails
   sass-rails (~> 5.0)
-  sdoc (~> 0.4.0)
+  sdoc
   spring
   turbolinks
-  uglifier (>= 1.3.0)
+  uglifier
   web-console (~> 2.0)
 
 RUBY VERSION

--- a/rails_app/README.rdoc
+++ b/rails_app/README.rdoc
@@ -1,28 +1,4 @@
-== README
+# Application created to test RSpec test cases
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
-
-
-Please feel free to use a different markup language if you do not plan to run
-<tt>rake doc:app</tt>.
+* Ruby 2.6.5
+* Rails 5.2.X


### PR DESCRIPTION
Bumpimg websocket-extensions from 0.1.4 to 0.1.5 dependencies

``` 1 websocket-extensions vulnerability found in Gemfile.lock ```

**Remediation**
Upgrade websocket-extensions to version 0.1.5 or later. For example:

``` gem "websocket-extensions", ">= 0.1.5" - moderate severity ```

Always verify the validity and compatibility of suggestions with your codebase.

**Details**
GHSA-g6wq-qcwm-j5g2

Vulnerable versions: < 0.1.5
Patched version: 0.1.5

**Impact**
The ReDoS flaw allows an attacker to exhaust the server's capacity to process
incoming requests by sending a WebSocket handshake request containing a header
of the following form:

``` Sec-WebSocket-Extensions: a; b="\c\c\c\c\c\c\c\c\c\c ... ```

That is, a header containing an unclosed string parameter value whose content is
a repeating two-byte sequence of a backslash and some other character. The
parser takes exponential time to reject this header as invalid, and this will
block the processing of any other work on the same thread. Thus if you are
running a single-threaded server, such a request can render your service
completely unavailable.

**Patches**
Users should upgrade to version 0.1.5.

**Workarounds**
There are no known work-arounds other than disabling any public-facing WebSocket functionality you are operating.

**References**
``` https://blog.jcoglan.com/2020/06/02/redos-vulnerability-in-websocket-extensions/ ```